### PR TITLE
Disable JWT authentication on console requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.1
+
+### Fixed
+
+- Application crash on initialization.
+
 ## 0.2.0 - 2019-10-06
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "edenspiekermann/craft-jwt-auth",
   "description": "Enable authentication to Craft through the use of JSON Web Tokens (JWT)",
   "type": "craft-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "craft",
     "cms",

--- a/src/CraftJwtAuth.php
+++ b/src/CraftJwtAuth.php
@@ -58,7 +58,7 @@ class CraftJwtAuth extends Plugin
         parent::init();
         self::$plugin = $this;
 
-        Craft::$app->on(Application::EVENT_INIT, function (Event $event) {
+        Event::on(Application::class, Application::EVENT_INIT, function (Event $event) {
             $token = self::$plugin->jWT->parseAndVerifyJWT(self::$plugin->jWT->getJWTFromRequest());
 
             // If the token passes verification...


### PR DESCRIPTION
### Description

Previously the plugin would initialize itself on application load. This is fine, but `Craft::$app` may be either a `craft\web\Application` or a `craft\console\Application`, which are different applications with different use cases.

As seen in https://github.com/edenspiekermann/craft-jwt-auth/issues/11, this would cause all console requests to crash as the console application resolves a console request, and there is no `craft\console\Request::headers`.

This PR changes the class that the plugin initialzes on from `Craft->$app` to `craft\web\Application`, causing the plugin to not attempt to authenticate a user based on the current headers on console requests.

### Definition of Done

- [x] Ensure there are no formatting errors
- [x] Ensure feature branch has latest development code integrated
- [x] Version number in `composer.json` is updated
- [x] New entry added in `CHANGELOG.md` documenting changes made
