### PR TITLE
avoid a "not an object" exception where the user is still null after …

### DIFF
--- a/src/CraftJwtAuth.php
+++ b/src/CraftJwtAuth.php
@@ -72,7 +72,7 @@ class CraftJwtAuth extends Plugin
                 }
 
                 // Attempt to login as the user we have found or created
-                if ($user->id) {
+                if ($user && $user->id) {
                     Craft::$app->user->loginByUserId($user->id);
                 }
             }


### PR DESCRIPTION
…all checks

### Description

When it got to the end of `EVENT_INIT` code, if `$user` was still `null` at that point, the `$user->id` was throwing a "not an object" exception; just add an additional check before that to confirm `$user` is not `null`.

### Definition of Done

- [x] Ensure there are no formatting errors
- [x] Ensure feature branch has latest development code integrated
- [x] Version number in `composer.json` is updated
- [x] New entry added in `CHANGELOG.md` documenting changes made
